### PR TITLE
Handle case where history is `nil`

### DIFF
--- a/preload.lua
+++ b/preload.lua
@@ -14,7 +14,7 @@ configFileWatcher =
 
 -- persist console history across launches
 hs.shutdownCallback = function() hs.settings.set('history', hs.console.getHistory()) end
-hs.console.setHistory(hs.settings.get('history'))
+hs.console.setHistory(hs.settings.get('history') or {})
 
 -- ensure CLI installed
 hs.ipc.cliInstall()


### PR DESCRIPTION
Config has to successfully load and shutdown for history to have a non nil value.

If history is nil then load empty table instead.